### PR TITLE
Remove assumptions of physical cores and add more unit tests

### DIFF
--- a/reframe/core/schedulers/lsf.py
+++ b/reframe/core/schedulers/lsf.py
@@ -51,8 +51,8 @@ class LsfJobScheduler(PbsJobScheduler):
             preamble.append(self._format_option(job.num_tasks, '-n {0}'))
 
         if job.num_cpus_per_task is not None:
-            num_physical_cores = job.num_tasks * job.num_cpus_per_task
-            preamble.append(self._format_option(num_physical_cores, '-R "span[ptile={0}]"'))
+            preamble.append(self._format_option(job.num_cpus_per_task,
+                                                '-R "span[ptile={0}]"'))
 
         # add job time limit in minutes
         if job.time_limit is not None:

--- a/reframe/core/schedulers/lsf.py
+++ b/reframe/core/schedulers/lsf.py
@@ -52,7 +52,7 @@ class LsfJobScheduler(PbsJobScheduler):
 
         if job.num_cpus_per_task is not None:
             preamble.append(self._format_option(job.num_cpus_per_task,
-                                                '-R "span[ptile={0}]"'))
+                                                '-R "affinity[core({0})]"'))
 
         # add job time limit in minutes
         if job.time_limit is not None:

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -140,7 +140,7 @@ def _expected_lsf_directives(job):
         f'#BSUB -e {job.stderr}',
         f'#BSUB -nnodes {job.num_tasks // job.num_tasks_per_node}',
         f'#BSUB -W {int(job.time_limit // 60)}',
-        f'#BSUB -R "span[ptile={job.num_cpus_per_task}]"',
+        f'#BSUB -R "affinity[core({job.num_cpus_per_task})]"',
         f'#BSUB -x',
         f'#BSUB --account=spam',
         f'#BSUB --gres=gpu:4',

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -134,19 +134,13 @@ def assert_job_script_sanity(job):
 
 
 def _expected_lsf_directives(job):
-    num_tasks = job.num_tasks or 1
-    num_tasks_per_node = job.num_tasks_per_node or 1
-    ptile = min(
-        num_tasks * job.num_cpus_per_task,
-        num_tasks_per_node * job.num_cpus_per_task
-    )
     return set([
         f'#BSUB -J testjob',
         f'#BSUB -o {job.stdout}',
         f'#BSUB -e {job.stderr}',
-        f'#BSUB -n {num_tasks}',
+        f'#BSUB -nnodes {job.num_tasks // job.num_tasks_per_node}',
         f'#BSUB -W {int(job.time_limit // 60)}',
-        f'#BSUB -R "span[ptile={ptile}]"',
+        f'#BSUB -R "span[ptile={job.num_cpus_per_task}]"',
         f'#BSUB -x',
         f'#BSUB --account=spam',
         f'#BSUB --gres=gpu:4',


### PR DESCRIPTION
This removes the assumption about physical cores in the backend and adds more unit tests. As described in the issue, I believe that the physical cores information should be collected by the test and set at the test level using the `num_cpus_per_task`. With that, I think we can merge the LSF backend in the upstream.